### PR TITLE
Actualize `nodejs` version in CI

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -35,6 +35,8 @@ jobs:
     - name: Check `simplecov` branch coverage
       run: cat coverage/.last_run.json | jq '.result.branch' | grep -q '100'
     - uses: actions/setup-node@v1
+      with:
+        node-version: '16'
     - name: Check markdown files using `markdownlint`
       run: |
         npm install -g markdownlint-cli

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### Changes
 
 * Remove `ruby-2.5` from CI since it's EOLed
+* Actualize `nodejs` version in CI
 
 ## 0.6.0 (2021-12-22)
 


### PR DESCRIPTION
Without it `markdownlint-cli` started to fail