### PR TITLE
Fix `gem` warning about `metadata` field

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 ### Fixes
 
 * Fix `gem` warning about license name
+* Fix `gem` warning about `metadata` field
 
 ## 1.0.0 (2022-08-06)
 

--- a/onlyoffice_s3_wrapper.gemspec
+++ b/onlyoffice_s3_wrapper.gemspec
@@ -16,7 +16,6 @@ Gem::Specification.new do |s|
     'bug_tracker_uri' => "#{s.homepage}/issues",
     'changelog_uri' => "#{s.homepage}/blob/master/CHANGELOG.md",
     'documentation_uri' => "https://www.rubydoc.info/gems/#{s.name}",
-    'homepage_uri' => s.homepage,
     'source_code_uri' => s.homepage,
     'rubygems_mfa_required' => 'true'
   }


### PR DESCRIPTION
The warning is:
```
WARNING:  You have specified the uri:
  https://github.com/ONLYOFFICE-QA/onlyoffice_s3_wrapper
for all of the following keys:
  homepage_uri
  source_code_uri
Only the first one will be shown on rubygems.org
```